### PR TITLE
fix: Infinite loop of requests + default name depending on action when saving

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,13 @@
         "@stripe/react-stripe-js": "^2.8.0",
         "@stripe/stripe-js": "^4.5.0",
         "@turf/turf": "^7.1.0",
+        "@types/html2canvas": "^1.0.0",
         "ag-grid-community": "31.3.2",
         "ag-grid-react": "31.3.2",
         "axios": "^1.7.4",
         "clsx": "^2.1.1",
+        "html2canvas": "^1.4.1",
+        "lodash": "^4.17.21",
         "mapbox-gl": "^3.3.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -28,6 +31,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
+        "@types/mapbox__mapbox-gl-draw": "^1.4.8",
         "@types/mapbox-gl": "^3.4.0",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -3690,6 +3694,25 @@
       "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==",
       "license": "MIT"
     },
+    "node_modules/@types/html2canvas": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/html2canvas/-/html2canvas-1.0.0.tgz",
+      "integrity": "sha512-BJpVf+FIN9UERmzhbtUgpXj6XBZpG67FMgBLLoj9HZKd9XifcCpSV+UnFcwTZfEyun4U/KmCrrVOG7829L589w==",
+      "deprecated": "This is a stub types definition. html2canvas provides its own type definitions, so you do not need this installed.",
+      "dependencies": {
+        "html2canvas": "*"
+      }
+    },
+    "node_modules/@types/mapbox__mapbox-gl-draw": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__mapbox-gl-draw/-/mapbox__mapbox-gl-draw-1.4.8.tgz",
+      "integrity": "sha512-700zPikQXfFMB2vtkJdXSROiqS5F19guf6QdYqvlgCdaMxGmdlLITRq6/zFpzfVQDrgpWex5M8vLtbwjZfup8g==",
+      "dev": true,
+      "dependencies": {
+        "@types/geojson": "*",
+        "mapbox-gl": "*"
+      }
+    },
     "node_modules/@types/mapbox-gl": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-3.4.0.tgz",
@@ -4228,6 +4251,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -4502,6 +4533,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/csscolorparser": {
@@ -5682,6 +5721,18 @@
         "node": "*"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -6195,6 +6246,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -7702,6 +7758,14 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -8099,6 +8163,14 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/vaul": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "axios": "^1.7.4",
     "clsx": "^2.1.1",
     "html2canvas": "^1.4.1",
+    "lodash": "^4.17.21",
     "mapbox-gl": "^3.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/context/LayerContext.tsx
+++ b/src/context/LayerContext.tsx
@@ -8,8 +8,8 @@ import React, {
   useRef,
   useEffect,
   useMemo,
-} from "react";
-import { HttpReq } from "../services/apiService";
+} from "react"
+import { HttpReq } from "../services/apiService"
 import {
   FetchDatasetResponse,
   LayerContextType,
@@ -21,118 +21,122 @@ import {
   LayerCustomization,
   LayerState,
   MapFeatures,
-} from "../types/allTypesAndInterfaces";
-import urls from "../urls.json";
-import { useCatalogContext } from "./CatalogContext";
-import userIdData from "../currentUserId.json";
-import { useAuth } from "../context/AuthContext";
-import { useNavigate } from "react-router-dom";
-import { processCityData, getDefaultLayerColor } from "../utils/helperFunctions";
-import apiRequest from "../services/apiRequest";
-import { defaultMapConfig } from "../hooks/map/useMapInitialization";
-import { useMapContext } from './MapContext';
+} from "../types/allTypesAndInterfaces"
+import urls from "../urls.json"
+import { useCatalogContext } from "./CatalogContext"
+import userIdData from "../currentUserId.json"
+import { useAuth } from "../context/AuthContext"
+import { useNavigate } from "react-router-dom"
+import { processCityData, getDefaultLayerColor } from "../utils/helperFunctions"
+import apiRequest from "../services/apiRequest"
+import { defaultMapConfig } from "../hooks/map/useMapInitialization"
+import { useMapContext } from "./MapContext"
 
-const LayerContext = createContext<LayerContextType | undefined>(undefined);
+const LayerContext = createContext<LayerContextType | undefined>(undefined)
 
 export function LayerProvider(props: { children: ReactNode }) {
-  const navigate = useNavigate();
-  const { authResponse } = useAuth();
-  const { children } = props;
-  const { geoPoints, setGeoPoints } = useCatalogContext();
+  const navigate = useNavigate()
+  const { authResponse } = useAuth()
+  const { children } = props
+  const { geoPoints, setGeoPoints } = useCatalogContext()
   // State from useLocationAndCategories
-  const [countries, setCountries] = useState<string[]>([]);
-  const [cities, setCities] = useState<City[]>([]);
+  const [countries, setCountries] = useState<string[]>([])
+  const [cities, setCities] = useState<City[]>([])
   const [citiesData, setCitiesData] = useState<{ [country: string]: City[] }>(
     {}
-  );
-  const [categories, setCategories] = useState<CategoryData>({});
+  )
+  const [categories, setCategories] = useState<CategoryData>({})
   const [reqFetchDataset, setReqFetchDataset] = useState<ReqFetchDataset>({
     selectedCountry: "",
     selectedCity: "",
     layers: [],
     includedTypes: [],
     excludedTypes: [],
-    zoomLevel: defaultMapConfig.zoomLevel
-  });
+    zoomLevel: defaultMapConfig.zoomLevel,
+  })
   const [reqSaveLayer, setReqSaveLayer] = useState({
     legend: "",
     description: "",
     name: "",
-  });
+  })
 
   const [createLayerformStage, setCreateLayerformStage] =
-    useState<string>("initial");
-  const [loading, setLoading] = useState<boolean>(false);
-  const [isError, setIsError] = useState<Error | null>(null);
+    useState<string>("initial")
+  const [loading, setLoading] = useState<boolean>(false)
+  const [isError, setIsError] = useState<Error | null>(null)
   const [manyFetchDatasetResp, setManyFetchDatasetResp] = useState<
     FetchDatasetResponse | undefined
-  >(undefined);
+  >(undefined)
   const [FetchDatasetResp, setFetchDatasetResp] =
-    useState<FetchDatasetResponse | null>(null);
-  const [saveMethod, setSaveMethod] = useState<string>("");
+    useState<FetchDatasetResponse | null>(null)
+  const [saveMethod, setSaveMethod] = useState<string>("")
   const [datasetInfo, setDatasetInfo] = useState<{
-    bknd_dataset_id: string;
-    prdcer_lyr_id: string;
-  } | null>(null);
+    bknd_dataset_id: string
+    prdcer_lyr_id: string
+  } | null>(null)
 
-  const [saveResponse, setSaveResponse] = useState<SaveResponse | null>(null);
-  const [saveResponseMsg, setSaveResponseMsg] = useState<string>("");
-  const [saveReqId, setSaveReqId] = useState<string>("");
+  const [saveResponse, setSaveResponse] = useState<SaveResponse | null>(null)
+  const [saveResponseMsg, setSaveResponseMsg] = useState<string>("")
+  const [saveReqId, setSaveReqId] = useState<string>("")
 
   const [selectedColor, setSelectedColor] = useState<{
-    name: string;
-    hex: string;
-  } | null>(null);
-  const [saveOption, setSaveOption] = useState<string>("");
+    name: string
+    hex: string
+  } | null>(null)
+  const [saveOption, setSaveOption] = useState<string>("")
 
-  const [centralizeOnce, setCentralizeOnce] = useState<boolean>(false);
-  const [initialFlyToDone, setInitialFlyToDone] = useState<boolean>(false);
+  const [centralizeOnce, setCentralizeOnce] = useState<boolean>(false)
+  const [initialFlyToDone, setInitialFlyToDone] = useState<boolean>(false)
 
-  const [showLoaderTopup, setShowLoaderTopup] = useState<boolean>(false);
+  const [showLoaderTopup, setShowLoaderTopup] = useState<boolean>(false)
 
-  const [postResMessage, setPostResMessage] = useState<string>("");
-  const [postResId, setPostResId] = useState<string>("");
+  const [postResMessage, setPostResMessage] = useState<string>("")
+  const [postResId, setPostResId] = useState<string>("")
 
-  const [localLoading, setLocalLoading] = useState<boolean>(false);
-  const [textSearchInput, setTextSearchInput] = useState<string>("");
-  const [searchType, setSearchType] = useState<string>("category_search");
-  const [password, setPassword] = useState<string>("");
+  const [localLoading, setLocalLoading] = useState<boolean>(false)
+  const [textSearchInput, setTextSearchInput] = useState<string>("")
+  const [searchType, setSearchType] = useState<string>("category_search")
+  const [password, setPassword] = useState<string>("")
 
-  const pageCountsRef = useRef<{[layerId: string]: number}>({});
-  const MAX_CALLS = 10;
+  const pageCountsRef = useRef<{ [layerId: string]: number }>({})
+  const MAX_CALLS = 10
 
-  const [layerDataMap, setLayerDataMap] = useState<LayerDataMap>({});
+  const [layerDataMap, setLayerDataMap] = useState<LayerDataMap>({})
 
-  const [selectedCountry, setSelectedCountry] = useState<string>("");
-  const [selectedCity, setSelectedCity] = useState<string>("");
+  const [selectedCountry, setSelectedCountry] = useState<string>("")
+  const [selectedCity, setSelectedCity] = useState<string>("")
 
-  const [layerStates, setLayerStates] = useState<{ [layerId: number]: LayerState }>({});
+  const [layerStates, setLayerStates] = useState<{
+    [layerId: number]: LayerState
+  }>({})
 
-  const { backendZoom } = useMapContext();
+  const { backendZoom } = useMapContext()
 
   // Memoize the zoom level
-  const currentZoomLevel = useMemo(() => 
-    backendZoom ?? defaultMapConfig.zoomLevel,
+  const currentZoomLevel = useMemo(
+    () => backendZoom ?? defaultMapConfig.zoomLevel,
     [backendZoom]
-  );
+  )
 
   function incrementFormStage() {
     if (createLayerformStage === "initial") {
-      setCreateLayerformStage("secondStep");
+      setCreateLayerformStage("secondStep")
     } else if (createLayerformStage === "secondStep") {
-      setCreateLayerformStage("thirdStep");
+      setCreateLayerformStage("thirdStep")
     }
   }
 
-  async function handleSaveLayer(layerData: LayerCustomization | { layers: LayerCustomization[] }) {
-    if ('layers' in layerData) {
+  async function handleSaveLayer(
+    layerData: LayerCustomization | { layers: LayerCustomization[] }
+  ) {
+    if ("layers" in layerData) {
       // Handle multiple layers
       for (const layer of layerData.layers) {
-        await saveSingleLayer(layer);
+        await saveSingleLayer(layer)
       }
     } else {
       // Handle single layer
-      await saveSingleLayer(layerData);
+      await saveSingleLayer(layerData)
     }
   }
 
@@ -146,7 +150,7 @@ export function LayerProvider(props: { children: ReactNode }) {
       layer_description: layerData.description,
       city_name: reqFetchDataset.selectedCity,
       user_id: authResponse?.localId,
-    };
+    }
 
     try {
       const res = await apiRequest({
@@ -154,126 +158,153 @@ export function LayerProvider(props: { children: ReactNode }) {
         method: "post",
         body: postData,
         isAuthRequest: true,
-      });
-      setSaveResponse(res.data.data);
-      setSaveResponseMsg(res.data.message);
-      setSaveReqId(res.data.id);
+      })
+      setSaveResponse(res.data.data)
+      setSaveResponseMsg(res.data.message)
+      setSaveReqId(res.data.id)
     } catch (error) {
-      setIsError(error instanceof Error ? error : new Error(String(error)));
+      setIsError(error instanceof Error ? error : new Error(String(error)))
     }
   }
 
   function resetFormStage() {
-    setIsError(null);
-    setCreateLayerformStage("initial");
+    setIsError(null)
+    setCreateLayerformStage("initial")
   }
 
-  function updateGeoJSONDataset(response: FetchDatasetResponse, layerId: number, defaultName: string) {
+  async function updateGeoJSONDataset(
+    response: FetchDatasetResponse,
+    layerId: number,
+    defaultName: string
+  ) {
     setGeoPoints((prevPoints: MapFeatures[] | MapFeatures | any) => {
-      const layerKey = String(layerId);
-      pageCountsRef.current[layerKey] = (pageCountsRef.current[layerKey] || 0) + 1;
+      const layerKey = String(layerId)
+
+      // Increment the call count for this layer
+      pageCountsRef.current[layerKey] =
+        (pageCountsRef.current[layerKey] || 0) + 1
 
       // Skip merging if response has no features
       if (!response.features?.length) {
-        console.warn(`No features in response for layer ${layerId}, skipping...`);
-        return prevPoints;
+        console.warn(
+          `No features in response for layer ${layerId}, skipping...`
+        )
+        return prevPoints
       }
 
-      const existingPoint = prevPoints.find((p: MapFeatures) => String(p.layerId) === String(layerId));
-      
+      const existingPoint = prevPoints.find(
+        (p: MapFeatures) => String(p.layerId) === String(layerId)
+      )
+
       const newPoint = {
-        type: 'FeatureCollection',
+        type: "FeatureCollection",
         features: [
-          ...(existingPoint?.features || []),  // Keep existing features if any
-          ...response.features.map(f => ({ 
-            type: 'Feature',
+          ...(existingPoint?.features || []), // Keep existing features if any
+          ...response.features.map((f) => ({
+            type: "Feature",
             geometry: f.geometry,
             properties: f.properties,
-            layerId: String(layerId)
-          }))
+            layerId: String(layerId),
+          })),
         ],
         display: true,
-        points_color: existingPoint?.points_color || getDefaultLayerColor(layerId),
+        points_color:
+          existingPoint?.points_color || getDefaultLayerColor(layerId),
         layerId: String(layerId),
         city_name: reqFetchDataset.selectedCity,
         layer_legend: defaultName,
         prdcer_layer_name: defaultName,
         prdcer_lyr_id: response.prdcer_lyr_id,
-        bknd_dataset_id: response.bknd_dataset_id
-      };
-
-      const filteredPoints = prevPoints.filter(p => 
-        String(p.layerId) !== String(layerId)
-      );
-      const newPoints = [...filteredPoints, newPoint];
-
-      // Continue pagination even if current page had issues
-      if (response.next_page_token && pageCountsRef.current[layerKey] < MAX_CALLS) {
-        handleFetchDataset("full data", response.next_page_token).catch(err => {
-          console.error(`Error fetching page for layer ${layerId}:`, err);
-          // Continue to next page despite error
-          if (pageCountsRef.current[layerKey] < MAX_CALLS) {
-            handleFetchDataset("full data", response.next_page_token);
-          }
-        });
-      } else {
-        setShowLoaderTopup(false);
-        delete pageCountsRef.current[layerKey];
+        bknd_dataset_id: response.bknd_dataset_id,
       }
-      
-      return newPoints;
-    });
+
+      const filteredPoints = prevPoints.filter(
+        (p) => String(p.layerId) !== String(layerId)
+      )
+      const newPoints = [...filteredPoints, newPoint]
+
+      // Handle pagination
+      if (
+        response.next_page_token &&
+        pageCountsRef.current[layerKey] < MAX_CALLS
+      ) {
+        handleFetchDataset(
+          "full data",
+          response.next_page_token,
+          layerId
+        ).catch((err) => {
+          console.error(`Error fetching page for layer ${layerId}:`, err)
+        })
+      } else {
+        delete pageCountsRef.current[layerKey] // Remove from tracking
+      }
+
+      return newPoints
+    })
   }
 
-  async function handleFetchDataset(action: string, pageToken?: string) {    
-    // Clear existing data on initial request (when no pageToken)
-    if (!pageToken) {
-      setGeoPoints([]);
-      setLayerDataMap({});
+  async function handleFetchDataset(
+    action: string,
+    pageToken?: string,
+    layerId?: number
+  ) {
+    // Clear existing data on the initial request
+    if (!pageToken && !layerId) {
+      setGeoPoints([])
+      setLayerDataMap({})
     }
 
-    let user_id: string;
-    let idToken: string;
+    let user_id: string
+    let idToken: string
 
     try {
       if (authResponse && "idToken" in authResponse) {
-        user_id = authResponse.localId;
-        idToken = authResponse.idToken;
+        user_id = authResponse.localId
+        idToken = authResponse.idToken
       } else if (action == "full data") {
-        navigate("/auth");
-        setIsError(new Error("User is not authenticated!"));
-        return;
+        navigate("/auth")
+        setIsError(new Error("User is not authenticated!"))
+        return
       } else {
-        user_id = "0000";
-        idToken = "";
+        user_id = "0000"
+        idToken = ""
       }
 
-      for (const layer of reqFetchDataset.layers) {
+      const layers = layerId
+        ? [reqFetchDataset.layers.find((l) => l.id === layerId)]
+        : reqFetchDataset.layers
+
+      for (const layer of layers) {
         try {
+          if (!layer) continue
+
           // Verify that this layer ID isn't already processed
           if (layerDataMap[layer.id]) {
-            console.warn(`Layer ${layer.id} already processed, skipping...`);
-            continue;
+            console.warn(`Layer ${layer.id} already processed, skipping...`)
+            continue
           }
 
-          // Generate default name for layer
-          const defaultName = `${reqFetchDataset.selectedCountry} ${reqFetchDataset.selectedCity} ${
-            layer.includedTypes?.map(type => type.replace("_", " ")).join(" + ") || ''
+          const defaultName = `${reqFetchDataset.selectedCountry} ${
+            reqFetchDataset.selectedCity
+          } ${
+            layer.includedTypes
+              ?.map((type) => type.replace("_", " "))
+              .join(" + ") || ""
           }${
-            layer.excludedTypes?.length > 0 
-              ? " + not " + layer.excludedTypes.map(type => type.replace("_", " ")).join(" + not ")
+            layer.excludedTypes?.length > 0
+              ? " + not " +
+                layer.excludedTypes
+                  .map((type) => type.replace("_", " "))
+                  .join(" + not ")
               : ""
-          }`;
+          }`
 
-          //TODO: Further improve when working on the "OR" feature
           const res = await apiRequest({
             url: urls.fetch_dataset,
             method: "post",
             body: {
               country_name: reqFetchDataset.selectedCountry,
               city_name: reqFetchDataset.selectedCity,
-              //includedTypes: layer.includedTypes || [],
-              //excludedTypes: layer.excludedTypes || [],
               boolean_query: layer.includedTypes?.join(" OR "),
               layerId: layer.id,
               layer_name: defaultName,
@@ -285,26 +316,26 @@ export function LayerProvider(props: { children: ReactNode }) {
               zoom_level: currentZoomLevel,
             },
             isAuthRequest: true,
-          });
+          })
 
           if (res?.data?.data) {
-            setLayerDataMap(prev => ({
+            setLayerDataMap((prev) => ({
               ...prev,
-              [layer.id]: res.data.data
-            }));
-            
-            updateGeoJSONDataset(res.data.data, layer.id, defaultName);
+              [layer.id]: res.data.data,
+            }))
+
+            updateGeoJSONDataset(res.data.data, layer.id, defaultName)
           }
         } catch (error) {
-          console.error(`Error fetching layer ${layer.id}:`, error);
-          setIsError(error instanceof Error ? error : new Error(String(error)));
+          console.error(`Error fetching layer ${layer?.id}:`, error)
+          setIsError(error instanceof Error ? error : new Error(String(error)))
         }
       }
     } catch (error) {
-      setIsError(error instanceof Error ? error : new Error(String(error)));
+      setIsError(error instanceof Error ? error : new Error(String(error)))
     } finally {
-      // Set loader back to false after all operations complete
-      setShowLoaderTopup(false);
+      // Reset loader
+      setShowLoaderTopup(false)
     }
   }
 
@@ -321,20 +352,20 @@ export function LayerProvider(props: { children: ReactNode }) {
       const res = await apiRequest({
         url: urls.country_city,
         method: "get",
-      });
-      setCountries(processCityData(res.data.data, setCitiesData));
+      })
+      setCountries(processCityData(res.data.data, setCitiesData))
     } catch (error) {
-      setIsError(error);
+      setIsError(error)
     }
 
     try {
       const res = await apiRequest({
         url: urls.nearby_categories,
         method: "get",
-      });
-      setCategories(res.data.data);
+      })
+      setCategories(res.data.data)
     } catch (error) {
-      setIsError(error);
+      setIsError(error)
     }
     // HttpReq<CategoryData>(
     //   urls.nearby_categories,
@@ -349,32 +380,32 @@ export function LayerProvider(props: { children: ReactNode }) {
   function handleCountryCitySelection(
     event: React.ChangeEvent<HTMLSelectElement>
   ) {
-    const { name, value } = event.target;
+    const { name, value } = event.target
 
     if (name === "selectedCountry") {
       // Update country and reset city
-      setSelectedCountry(value);
-      setSelectedCity("");
-      
+      setSelectedCountry(value)
+      setSelectedCity("")
+
       // Get cities for selected country
-      const selectedCountryCities = citiesData[value] || [];
-      setCities(selectedCountryCities);
+      const selectedCountryCities = citiesData[value] || []
+      setCities(selectedCountryCities)
 
       // Update reqFetchDataset
-      setReqFetchDataset(prev => ({
+      setReqFetchDataset((prev) => ({
         ...prev,
         selectedCountry: value,
         selectedCity: "", // Reset city when country changes
-      }));
+      }))
     } else if (name === "selectedCity") {
       // Update city
-      setSelectedCity(value);
-      
+      setSelectedCity(value)
+
       // Update reqFetchDataset
-      setReqFetchDataset(prev => ({
+      setReqFetchDataset((prev) => ({
         ...prev,
         selectedCity: value,
-      }));
+      }))
     }
   }
 
@@ -385,32 +416,36 @@ export function LayerProvider(props: { children: ReactNode }) {
           ...prevData,
           includedTypes: prevData.includedTypes.filter((t) => t !== type),
           excludedTypes: [...prevData.excludedTypes, type],
-        };
+        }
       } else if (prevData.excludedTypes.includes(type)) {
         return {
           ...prevData,
           excludedTypes: prevData.excludedTypes.filter((t) => t !== type),
-        };
+        }
       } else {
         return {
           ...prevData,
           includedTypes: [...prevData.includedTypes, type],
-        };
+        }
       }
-    });
+    })
   }
 
   function validateFetchDatasetForm() {
     if (!reqFetchDataset.selectedCountry || !reqFetchDataset.selectedCity) {
-      return new Error("Country and city are required.");
+      return new Error("Country and city are required.")
     }
     if (
       reqFetchDataset.includedTypes.length === 0 &&
       reqFetchDataset.excludedTypes.length === 0 &&
       searchType !== "keyword_search"
     ) {
-      console.log("At least one category must be included or excluded.", reqFetchDataset, searchType);
-      return new Error("At least one category must be included or excluded.");
+      console.log(
+        "At least one category must be included or excluded.",
+        reqFetchDataset,
+        searchType
+      )
+      return new Error("At least one category must be included or excluded.")
     }
     if (
       reqFetchDataset.includedTypes.length > 50 ||
@@ -418,14 +453,14 @@ export function LayerProvider(props: { children: ReactNode }) {
     ) {
       return new Error(
         "Up to 50 types can be specified in each type restriction category."
-      );
+      )
     }
-    return true;
+    return true
   }
 
   useEffect(() => {
-    console.log("searchType", searchType);
-  }, [searchType]);
+    console.log("searchType", searchType)
+  }, [searchType])
 
   function resetFetchDatasetForm() {
     setReqFetchDataset({
@@ -434,58 +469,58 @@ export function LayerProvider(props: { children: ReactNode }) {
       layers: [],
       includedTypes: [],
       excludedTypes: [],
-      zoomLevel: defaultMapConfig.zoomLevel
-    });
-    setLayerDataMap({});
-    setSelectedCountry(""); // Reset country
-    setSelectedCity(""); // Reset city
-    setTextSearchInput("");
-    setSearchType("category_search");
-    setPassword("");
-    setGeoPoints([]);
+      zoomLevel: defaultMapConfig.zoomLevel,
+    })
+    setLayerDataMap({})
+    setSelectedCountry("") // Reset country
+    setSelectedCity("") // Reset city
+    setTextSearchInput("")
+    setSearchType("category_search")
+    setPassword("")
+    setGeoPoints([])
   }
 
   useEffect(() => {
     if (isError) {
-      setShowLoaderTopup(false);
+      setShowLoaderTopup(false)
     }
-  }, [isError]);
+  }, [isError])
 
   useEffect(() => {
-    handleGetCountryCityCategory();
-  }, []);
+    handleGetCountryCityCategory()
+  }, [])
 
   const updateLayerState = (layerId: number, updates: Partial<LayerState>) => {
-    setLayerStates(prev => ({
+    setLayerStates((prev) => ({
       ...prev,
       [layerId]: {
         ...prev[layerId],
-        ...updates
-      }
-    }));
-  };
+        ...updates,
+      },
+    }))
+  }
 
   useEffect(() => {
     if (reqFetchDataset?.layers?.length > 0) {
       // Initialize layer states while preserving existing states
-      setLayerStates(prev => {
+      setLayerStates((prev) => {
         const initialStates = reqFetchDataset.layers.reduce((acc, layer) => {
-          if (layer && typeof layer.id === 'number') {
+          if (layer && typeof layer.id === "number") {
             acc[layer.id] = {
               ...prev[layer.id], // Preserve existing state if any
               selectedColor: prev[layer.id]?.selectedColor || null,
               isLoading: false, // Reset loading state
               saveResponse: prev[layer.id]?.saveResponse || null,
-              datasetInfo: prev[layer.id]?.datasetInfo || null
-            };
+              datasetInfo: prev[layer.id]?.datasetInfo || null,
+            }
           }
-          return acc;
-        }, {} as { [key: number]: LayerState });
+          return acc
+        }, {} as { [key: number]: LayerState })
 
-        return initialStates;
-      });
+        return initialStates
+      })
     }
-  }, [reqFetchDataset?.layers]);
+  }, [reqFetchDataset?.layers])
 
   return (
     <LayerContext.Provider
@@ -555,13 +590,13 @@ export function LayerProvider(props: { children: ReactNode }) {
     >
       {children}
     </LayerContext.Provider>
-  );
+  )
 }
 
 export function useLayerContext() {
-  const context = useContext(LayerContext);
+  const context = useContext(LayerContext)
   if (!context) {
-    throw new Error("useLayerContext must be used within a LayerProvider");
+    throw new Error("useLayerContext must be used within a LayerProvider")
   }
-  return context;
+  return context
 }

--- a/src/context/LayerContext.tsx
+++ b/src/context/LayerContext.tsx
@@ -274,6 +274,11 @@ export function LayerProvider(props: { children: ReactNode }) {
         ? [reqFetchDataset.layers.find((l) => l.id === layerId)]
         : reqFetchDataset.layers
 
+      setReqFetchDataset((prev) => ({
+        ...prev,
+        action: action,
+      }))
+
       for (const layer of layers) {
         try {
           if (!layer) continue
@@ -284,7 +289,7 @@ export function LayerProvider(props: { children: ReactNode }) {
             continue
           }
 
-          const defaultName = `${reqFetchDataset.selectedCountry} ${
+          const defaultName = ` ${reqFetchDataset.selectedCountry} ${
             reqFetchDataset.selectedCity
           } ${
             layer.includedTypes


### PR DESCRIPTION
- FRONTEND: (bug) fetching multiple layers at the same time on full data mode goes on infinite request loops, and doesn't handle errors received from the backend well
- 
-FRONTEND: when we save layer as sample and same layer as full data , we get 2 data but we don't know which is which, change the way we make names for layers to distinguish
