### PR TITLE
Cancel Layers fetch_dataset requests, when user switches from 'Layer' tab to another tab

### DIFF
--- a/src/context/LayerContext.tsx
+++ b/src/context/LayerContext.tsx
@@ -223,6 +223,7 @@ export function LayerProvider(props: { children: ReactNode }) {
     const isHomeRoute = location.pathname === '/';
     const isLayerTab = selectedContainerType === 'Layer';
     if (!isHomeRoute || !isLayerTab) {
+      //TODO comment , this should be a separate service.
       // Cancel all ongoing requests
       cancelSources.current.forEach(source => source.cancel('Request cancelled due to tab change from Layer tab'));
       cancelSources.current = [];

--- a/src/context/LayerContext.tsx
+++ b/src/context/LayerContext.tsx
@@ -218,16 +218,19 @@ export function LayerProvider(props: { children: ReactNode }) {
       return newPoints;
     });
   }
+  // Cancel all ongoing layer data requests when user switches from 'Layer' tab to another tab
   const cancelSources = useRef([]);
   const { createCancelToken, isCancellationError } = useRequestCancellation({
     cancelSourcesRef: cancelSources,
     conditions: {
       dependencies: [location.pathname, selectedContainerType],
-      shouldCancel: (pathname, containerType) => 
+      shouldCancel: (pathname, containerType) =>
         pathname !== '/' || containerType !== 'Layer',
       message: 'Request cancelled due to tab change from Layer tab'
     }
-  });  async function handleFetchDataset(action: string, pageToken?: string, layerId?: number) {
+  });
+
+  async function handleFetchDataset(action: string, pageToken?: string, layerId?: number) {
     if (!pageToken && !layerId) {
       setGeoPoints(prev => prev.filter(p => isIntelligentLayer(p)));
       setLayerDataMap({});

--- a/src/hooks/useRequestCancellation.ts
+++ b/src/hooks/useRequestCancellation.ts
@@ -1,0 +1,67 @@
+import { useEffect, MutableRefObject } from 'react';
+import axios, { CancelTokenSource } from 'axios';
+
+interface CancellationConfig {
+  cancelSourcesRef: MutableRefObject<CancelTokenSource[]>;
+  conditions?: {
+    dependencies: any[];
+    shouldCancel: (...deps: any[]) => boolean;
+    message?: string;
+  };
+  cleanupOnUnmount?: boolean;
+}
+
+export const useRequestCancellation = ({
+  cancelSourcesRef,
+  conditions,
+  cleanupOnUnmount = true
+}: CancellationConfig) => {
+  // Handle conditional cancellation
+  useEffect(() => {
+    if (conditions) {
+      const { dependencies, shouldCancel, message = 'Requests cancelled due to condition change' } = conditions;
+      
+      if (shouldCancel(...dependencies)) {
+        cancelAllRequests(message);
+      }
+    }
+  }, conditions ? conditions.dependencies : []);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    if (cleanupOnUnmount) {
+      return () => {
+        cancelAllRequests('Component unmounted');
+      };
+    }
+  }, []);
+
+  const createCancelToken = () => {
+    const source = axios.CancelToken.source();
+    cancelSourcesRef.current?.push(source);
+    return source;
+  };
+
+  const cancelRequest = (source: CancelTokenSource, message: string = 'Request cancelled') => {
+    source.cancel(message);
+    if (cancelSourcesRef.current) {
+      cancelSourcesRef.current = cancelSourcesRef.current.filter(s => s !== source);
+    }
+  };
+
+  const cancelAllRequests = (message: string = 'All requests cancelled') => {
+    if (cancelSourcesRef.current) {
+      cancelSourcesRef.current.forEach(source => source.cancel(message));
+      cancelSourcesRef.current = [];
+    }
+  };
+  const isCancellationError = (error: any) => {
+   return  axios.isCancel(error);
+  };
+  return {
+    createCancelToken,
+    cancelRequest,
+    cancelAllRequests,
+    isCancellationError
+  };
+};


### PR DESCRIPTION
**What's Changed**

1. Added request cancellation in `LayerContext` using `Axios cancellation tokens`
2. Track active fetch requests in a ref array
3. Cancel all pending `Layers fetch_dataset` requests when:
     User switches to Catalog tab (`selectedContainerType === 'Catalogue'`)

**Why This Matters**

1. Prevents memory leaks from abandoned requests
2. Stops outdated requests from completing after tab switches
3. Reduces unnecessary network/data usage