### PR TITLE
feat: add paywall modal for intel layers

### DIFF
--- a/src/components/CustomReportForm/components/PhoneVerificationStep.tsx
+++ b/src/components/CustomReportForm/components/PhoneVerificationStep.tsx
@@ -8,11 +8,20 @@ import urls from '../../../urls.json';
 interface PhoneVerificationStepProps {
   onVerificationSuccess: (phoneNumber: string) => void;
   disabled?: boolean;
+  /** Override the default title. Set to `null` to hide. */
+  title?: string | null;
+  /** Override the default subtitle. Set to `null` to hide. */
+  subtitle?: string | null;
+  /** Compact mode: smaller title, no outer shadow/padding — suited for inline use in modals */
+  compact?: boolean;
 }
 
 const PhoneVerificationStep: React.FC<PhoneVerificationStepProps> = ({
   onVerificationSuccess,
   disabled = false,
+  title,
+  subtitle,
+  compact = false,
 }) => {
   const { sendOTP, verifyOTP, state, resetState, isModalOpen, closeOTPModal } = useOTP();
   
@@ -129,7 +138,20 @@ const PhoneVerificationStep: React.FC<PhoneVerificationStepProps> = ({
 
   // Handle OTP input change
   const handleOtpChange = (index: number, value: string) => {
-    if (value.length > 1) return; // Prevent paste for now (handled separately if needed)
+    // If multiple digits entered (e.g. from autocomplete), treat as paste
+    if (value.length > 1) {
+      const digits = value.replace(/\D/g, '').slice(0, 6);
+      if (digits.length > 0) {
+        const newOtp = [...otpCode];
+        for (let i = 0; i < digits.length && index + i < 6; i++) {
+          newOtp[index + i] = digits[i];
+        }
+        setOtpCode(newOtp);
+        const focusIdx = Math.min(index + digits.length, 5);
+        inputRefs.current[focusIdx]?.focus();
+      }
+      return;
+    }
     if (!/^\d*$/.test(value)) return;
 
     const newOtp = [...otpCode];
@@ -140,6 +162,21 @@ const PhoneVerificationStep: React.FC<PhoneVerificationStepProps> = ({
     if (value && index < 5) {
       inputRefs.current[index + 1]?.focus();
     }
+  };
+
+  // Handle paste across all OTP inputs
+  const handleOtpPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    const pasted = e.clipboardData.getData('text').replace(/\D/g, '').slice(0, 6);
+    if (pasted.length === 0) return;
+    e.preventDefault();
+
+    const newOtp = [...otpCode];
+    for (let i = 0; i < pasted.length && i < 6; i++) {
+      newOtp[i] = pasted[i];
+    }
+    setOtpCode(newOtp);
+    const focusIdx = Math.min(pasted.length, 5);
+    inputRefs.current[focusIdx]?.focus();
   };
 
   const handleKeyDown = (index: number, e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -162,18 +199,35 @@ const PhoneVerificationStep: React.FC<PhoneVerificationStepProps> = ({
     );
   }
 
-  return (
-    <div className="max-w-xl mx-auto animate-fade-in-up">
-      <div className="text-center mb-8">
-        <h2 className="text-3xl font-extrabold text-gray-900 mb-3 tracking-tight">
-          Verify Your Phone
-        </h2>
-        <p className="text-lg text-gray-600">
-          We need to verify your phone number to generate the report.
-        </p>
-      </div>
+  const resolvedTitle = title === undefined ? 'Verify Your Phone' : title;
+  const resolvedSubtitle = subtitle === undefined
+    ? 'We need to verify your phone number to generate the report.'
+    : subtitle;
 
-      <div className="bg-white rounded-2xl p-8 shadow-lg border border-gray-100">
+  return (
+    <div className={`max-w-xl mx-auto ${compact ? '' : 'animate-fade-in-up'}`}>
+      {(resolvedTitle || resolvedSubtitle) && (
+        <div className={`text-center ${compact ? 'mb-4' : 'mb-8'}`}>
+          {resolvedTitle && (
+            <h2 className={compact
+              ? 'text-lg font-semibold text-gray-900 mb-1'
+              : 'text-3xl font-extrabold text-gray-900 mb-3 tracking-tight'
+            }>
+              {resolvedTitle}
+            </h2>
+          )}
+          {resolvedSubtitle && (
+            <p className={compact ? 'text-sm text-gray-600' : 'text-lg text-gray-600'}>
+              {resolvedSubtitle}
+            </p>
+          )}
+        </div>
+      )}
+
+      <div className={compact
+        ? 'bg-white rounded-lg p-6 border border-gray-200'
+        : 'bg-white rounded-2xl p-8 shadow-lg border border-gray-100'
+      }>
         {step === 'phone' ? (
           <form onSubmit={handleSendOTP} className="space-y-6">
             <div>
@@ -240,6 +294,7 @@ const PhoneVerificationStep: React.FC<PhoneVerificationStepProps> = ({
                   value={digit}
                   onChange={(e) => handleOtpChange(index, e.target.value)}
                   onKeyDown={(e) => handleKeyDown(index, e)}
+                  onPaste={handleOtpPaste}
                   className="w-10 h-12 sm:w-12 sm:h-14 text-center text-xl font-bold border-2 border-gray-200 rounded-lg focus:border-gem focus:ring-gem outline-none transition-all"
                   disabled={isLoading || disabled}
                 />

--- a/src/components/Map/AreaIntelligenceControl.tsx
+++ b/src/components/Map/AreaIntelligenceControl.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { useLayerContext } from '../../context/LayerContext';
 import { useCatalogContext } from '../../context/CatalogContext';
 import { LiaMapMarkedAltSolid } from 'react-icons/lia';
@@ -6,6 +6,20 @@ import { MdAttachMoney, MdHome } from 'react-icons/md';
 import { useIntelligenceViewport } from '../../context/IntelligenceViewPortContext';
 import { useClickOutside } from '../../hooks/useClickOutside';
 import { getYesterdayDate } from '../../utils/helperFunctions';
+import { useAuth, isGuestUser } from '../../context/AuthContext';
+import { useNavigate } from 'react-router-dom';
+import apiRequest from '../../services/apiRequest';
+import urls from '../../urls.json';
+import IntelligencePaywallModal, { type IntelligencePurchaseItem } from './IntelligencePaywallModal';
+
+type IntelligenceType = 'Population' | 'Income' | 'Real Estate';
+
+interface CartCostData {
+  total_cost: number;
+  intelligence_purchase_items: IntelligencePurchaseItem[];
+  dataset_purchase_items: unknown[];
+  report_purchase_items: unknown[];
+}
 
 export const AreaIntelligeneControl: React.FC = () => {
   const {
@@ -21,12 +35,20 @@ export const AreaIntelligeneControl: React.FC = () => {
   } = useLayerContext();
   const { populationSample, setPopulationSample, incomeSample, setIncomeSample, realEstateSample, setRealEstateSample } =
     useIntelligenceViewport();
+  const { authResponse } = useAuth();
+  const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false);
   const { selectedContainerType } = useCatalogContext();
   const [isPopulationRefetching, setIsPopulationRefetching] = useState(false);
   const [isIncomeRefetching, setIsIncomeRefetching] = useState(false);
   const [isRealEstateRefetching, setIsRealEstateRefetching] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  // Paywall state
+  const [isCheckingCost, setIsCheckingCost] = useState(false);
+  const [paywallData, setPaywallData] = useState<CartCostData | null>(null);
+  const [paywallIntelligences, setPaywallIntelligences] = useState<string[]>([]);
+  const [pendingAction, setPendingAction] = useState<(() => void) | null>(null);
 
   const close = () => setIsOpen(false);
 
@@ -40,6 +62,156 @@ export const AreaIntelligeneControl: React.FC = () => {
   useEffect(() => {
     close();
   }, [selectedContainerType]);
+
+  /**
+   * Check cost for an intelligence layer before enabling it.
+   * If cost=0 (already purchased), proceed immediately.
+   * If cost>0, show paywall modal.
+   */
+  const checkCostAndProceed = useCallback(async (
+    intelligenceNames: IntelligenceType[],
+    onProceed: () => void,
+  ) => {
+    // Not authenticated → redirect
+    if (!authResponse || !('idToken' in authResponse)) {
+      navigate('/auth');
+      return;
+    }
+
+    // Guest → redirect to register
+    if (isGuestUser(authResponse)) {
+      navigate('/auth?mode=register');
+      return;
+    }
+
+    setIsCheckingCost(true);
+    try {
+      const requestBody = {
+        user_id: authResponse.localId,
+        country_name: '',
+        city_name: '',
+        datasets: [] as string[],
+        intelligences: intelligenceNames,
+        displayed_price: 0,
+      };
+
+      const response = await apiRequest({
+        url: urls.calculate_cart_cost,
+        method: 'POST',
+        body: requestBody,
+        isAuthRequest: true,
+      });
+
+      const data: CartCostData = response.data?.data;
+
+      if (!data || data.total_cost === 0) {
+        // Already purchased or free → proceed directly
+        onProceed();
+      } else {
+        // Needs purchase → show paywall
+        setPaywallData(data);
+        setPaywallIntelligences(intelligenceNames);
+        setPendingAction(() => onProceed);
+      }
+    } catch (error) {
+      console.error('Error checking intelligence cost:', error);
+      // On error, proceed anyway — backend will catch it during data fetch
+      onProceed();
+    } finally {
+      setIsCheckingCost(false);
+    }
+  }, [authResponse, navigate]);
+
+  const handlePaywallClose = useCallback(() => {
+    setPaywallData(null);
+    setPaywallIntelligences([]);
+    setPendingAction(null);
+  }, []);
+
+  const handlePaywallSuccess = useCallback(() => {
+    if (pendingAction) {
+      pendingAction();
+    }
+    setPaywallData(null);
+    setPaywallIntelligences([]);
+    setPendingAction(null);
+  }, [pendingAction]);
+
+  // Wrapped toggle handlers that check cost first
+  const handlePopulationToggle = useCallback(() => {
+    if (includePopulation) {
+      // Turning OFF — no paywall needed
+      switchPopulationLayer();
+    } else {
+      // Turning ON — check cost
+      checkCostAndProceed(['Population'], () => {
+        switchPopulationLayer();
+      });
+    }
+  }, [includePopulation, switchPopulationLayer, checkCostAndProceed]);
+
+  const handleIncomeToggle = useCallback(() => {
+    if (includeIncome) {
+      switchIncomeLayer();
+    } else {
+      checkCostAndProceed(['Income'], () => {
+        switchIncomeLayer();
+      });
+    }
+  }, [includeIncome, switchIncomeLayer, checkCostAndProceed]);
+
+  const handleRealEstateToggle = useCallback(() => {
+    if (includeRealEstate) {
+      switchRealEstateLayer();
+    } else {
+      checkCostAndProceed(['Real Estate'], () => {
+        switchRealEstateLayer();
+      });
+    }
+  }, [includeRealEstate, switchRealEstateLayer, checkCostAndProceed]);
+
+  // Sample→Full toggle handlers with paywall check
+  const handlePopulationFull = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (populationSample) {
+      // Switching to Full — check if purchased
+      if (includePopulation) {
+        // Layer is active, switching mode
+        checkCostAndProceed(['Population'], () => {
+          setPopulationSample(false);
+        });
+      } else {
+        // Layer is off, just set the preference
+        setPopulationSample(false);
+      }
+    }
+  }, [populationSample, includePopulation, setPopulationSample, checkCostAndProceed]);
+
+  const handleIncomeFull = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (incomeSample) {
+      if (includeIncome) {
+        checkCostAndProceed(['Income'], () => {
+          setIncomeSample(false);
+        });
+      } else {
+        setIncomeSample(false);
+      }
+    }
+  }, [incomeSample, includeIncome, setIncomeSample, checkCostAndProceed]);
+
+  const handleRealEstateFull = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (realEstateSample) {
+      if (includeRealEstate) {
+        checkCostAndProceed(['Real Estate'], () => {
+          setRealEstateSample(false);
+        });
+      } else {
+        setRealEstateSample(false);
+      }
+    }
+  }, [realEstateSample, includeRealEstate, setRealEstateSample, checkCostAndProceed]);
 
   const handlePopulationRefetch = async () => {
     setIsPopulationRefetching(true);
@@ -69,467 +241,482 @@ export const AreaIntelligeneControl: React.FC = () => {
   };
 
   return (
-    <div ref={containerRef} className="relative z-[101]">
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className={`
-          flex items-center justify-center
-          h-[40px] sm:h-[47px] text-xs sm:text-base rounded-md p-1.5 sm:p-2
-          bg-gem-gradient border text-gray-200 border-gem/20 
-          shadow-lg transition-all duration-200
-          hover:bg-gray-100 min-w-[44px] sm:min-w-0
-          ${includeIncome || includePopulation || includeRealEstate ? 'bg-gem-green text-white hover:bg-[#0d4432]' : ''}
-        `}
-        title={'Area Intelligence'}
-      >
-        <div className="flex items-center justify-center w-full h-full">
-          <LiaMapMarkedAltSolid
-            size={20}
-            className={`
-              text-current sm:w-[22px] sm:h-[22px]
-              ${includePopulation || includeIncome || includeRealEstate ? 'text-white' : ''}
-              m-0.5 sm:m-2
-            `}
-          />
-          <span className="hidden sm:inline">Area Intelligence</span>
-        </div>
-      </button>
-
-      {isOpen && (
-        <div className="absolute left-0 mt-2 w-[min(calc(100vw-1rem),20rem)] sm:min-w-[26rem] sm:max-w-[42rem] z-50">
-          <div
-            className={`
-              relative flex flex-col p-3 sm:p-4 rounded-lg border 
-              transition-all duration-200 ease-in-out
-              text-gray-100 bg-gem-gradient border-gem-green/20
-              aria-disabled:opacity-80 aria-disabled:cursor-not-allowed
-            `}
-            title={'Activate area intelligence'}
-          >
-            <div className="font-semibold text-white text-sm sm:text-base">Area Intelligence</div>
-            <p className="text-[11px] sm:text-xs text-gray-300 mt-1">
-              Only one intelligence layer can be active at a time
-            </p>
-
-            <label
-              htmlFor="population-toggle-map"
+    <>
+      <div ref={containerRef} className="relative z-[101]">
+        <button
+          onClick={() => setIsOpen(!isOpen)}
+          className={`
+            flex items-center justify-center
+            h-[40px] sm:h-[47px] text-xs sm:text-base rounded-md p-1.5 sm:p-2
+            bg-gem-gradient border text-gray-200 border-gem/20
+            shadow-lg transition-all duration-200
+            hover:bg-gray-100 min-w-[44px] sm:min-w-0
+            ${includeIncome || includePopulation || includeRealEstate ? 'bg-gem-green text-white hover:bg-[#0d4432]' : ''}
+          `}
+          title={'Area Intelligence'}
+        >
+          <div className="flex items-center justify-center w-full h-full">
+            <LiaMapMarkedAltSolid
+              size={20}
               className={`
-                flex items-center justify-between 
-                border-t border-gem/20 mt-2 pt-2
-                bg-white/95 p-2 sm:p-3 rounded-md cursor-pointer
-                gap-1.5 sm:gap-1
+                text-current sm:w-[22px] sm:h-[22px]
+                ${includePopulation || includeIncome || includeRealEstate ? 'text-white' : ''}
+                m-0.5 sm:m-2
               `}
-            >
-              <div className="flex items-center gap-1.5 sm:gap-2 flex-1 min-w-0">
-                <div className="text-gem flex-shrink-0">
-                  <svg
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="18"
-                    height="18"
-                    className="sm:w-5 sm:h-5 min-w-[18px] sm:min-w-5"
-                  >
-                    <g>
-                      <path
-                        d="M18 7.16C17.94 7.15 17.87 7.15 17.81 7.16C16.43 7.11 15.33 5.98 15.33 4.58C15.33 3.15 16.48 2 17.91 2C19.34 2 20.49 3.16 20.49 4.58C20.48 5.98 19.38 7.11 18 7.16Z"
-                        strokeWidth="1.5"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        stroke="currentColor"
-                      />
-                      <path
-                        d="M16.9699 14.44C18.3399 14.67 19.8499 14.43 20.9099 13.72C22.3199 12.78 22.3199 11.24 20.9099 10.3C19.8399 9.59004 18.3099 9.35003 16.9399 9.59003"
-                        strokeWidth="1.5"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        stroke="currentColor"
-                      />
-                      <path
-                        d="M5.96998 7.16C6.02998 7.15 6.09998 7.15 6.15998 7.16C7.53998 7.11 8.63998 5.98 8.63998 4.58C8.63998 3.15 7.48998 2 6.05998 2C4.62998 2 3.47998 3.16 3.47998 4.58C3.48998 5.98 4.58998 7.11 5.96998 7.16Z"
-                        strokeWidth="1.5"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        stroke="currentColor"
-                      />
-                      <path
-                        d="M6.99994 14.44C5.62994 14.67 4.11994 14.43 3.05994 13.72C1.64994 12.78 1.64994 11.24 3.05994 10.3C4.12994 9.59004 5.65994 9.35003 7.02994 9.59003"
-                        strokeWidth="1.5"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        stroke="currentColor"
-                      />
-                      <path
-                        d="M12 14.63C11.94 14.62 11.87 14.62 11.81 14.63C10.43 14.58 9.32996 13.45 9.32996 12.05C9.32996 10.62 10.48 9.46997 11.91 9.46997C13.34 9.46997 14.49 10.63 14.49 12.05C14.48 13.45 13.38 14.59 12 14.63Z"
-                        strokeWidth="1.5"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        stroke="currentColor"
-                      />
-                      <path
-                        d="M9.08997 17.78C7.67997 18.72 7.67997 20.26 9.08997 21.2C10.69 22.27 13.31 22.27 14.91 21.2C16.32 20.26 16.32 18.72 14.91 17.78C13.32 16.72 10.69 16.72 9.08997 17.78Z"
-                        strokeWidth="1.5"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        stroke="currentColor"
-                      />
-                    </g>
-                  </svg>
-                </div>
-                <div className="flex flex-col min-w-0">
-                  <label className="font-medium text-gem text-xs sm:text-sm">
-                    Population Intelligence
-                  </label>
-                  <p className="text-xs sm:text-sm text-gem/80 mt-1 ">
-                    Enable smart population data
-                  </p>
-                  <p className="text-[10px] text-gray-500 mt-0.5">
-                    Updated on:{' '}
-                    <span className="text-[#115740] font-medium">{getYesterdayDate()}</span>
-                  </p>
-                </div>
-              </div>
-
-              <div className="flex items-center gap-1 sm:gap-2 flex-shrink-0">
-                <button
-                  onClick={handlePopulationRefetch}
-                  className="text-gem-green hover:text-gem-green/80 p-1"
-                  title="Refresh population data"
-                  disabled={isPopulationRefetching}
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="18"
-                    height="18"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    className={isPopulationRefetching ? 'animate-spin' : ''}
-                  >
-                    <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2" />
-                  </svg>
-                </button>
-                <div
-                  className="flex bg-gray-100 rounded p-0.5 border border-gray-200 flex-shrink-0"
-                  onClick={e => e.preventDefault()}
-                >
-                  <button
-                    onClick={e => {
-                      e.stopPropagation();
-                      setPopulationSample(true);
-                    }}
-                    className={`
-                      px-2 py-0.5 sm:px-3 sm:py-1 text-[10px] sm:text-xs rounded transition-all duration-200
-                      ${
-                        populationSample
-                          ? 'bg-white shadow-sm text-gem-green font-medium'
-                          : 'text-gray-500 hover:text-gray-700'
-                      }
-                    `}
-                  >
-                    Sample
-                  </button>
-                  <button
-                    onClick={e => {
-                      e.stopPropagation();
-                      setPopulationSample(false);
-                    }}
-                    className={`
-                      px-2 py-0.5 sm:px-3 sm:py-1 text-[10px] sm:text-xs rounded transition-all duration-200
-                      ${
-                        !populationSample
-                          ? 'bg-white shadow-sm text-gem-green font-medium'
-                          : 'text-gray-500 hover:text-gray-700'
-                      }
-                    `}
-                  >
-                    Full
-                  </button>
-                </div>
-                <div className="relative flex-shrink-0 ml-1 sm:ml-0">
-                  <input
-                    id="population-toggle-map"
-                    type="checkbox"
-                    checked={includePopulation}
-                    onChange={() => {
-                      switchPopulationLayer();
-                    }}
-                    className="sr-only peer"
-                  />
-                  <div
-                    className={`
-                      cursor-pointer
-                      w-12 h-6 sm:w-14 sm:h-7 bg-gray-200 
-                      peer-focus:outline-none peer-focus:ring-4 
-                      peer-focus:ring-gem-green/20 
-                      rounded-full peer
-                      peer-checked:bg-gem-green
-                      after:content-['']
-                      after:absolute 
-                      after:top-[2px] 
-                      after:left-[2px]
-                      after:bg-white 
-                      after:border-gray-300 
-                      after:border 
-                      after:rounded-full
-                      after:h-5 
-                      after:w-5 
-                      after:transition-all
-                      peer-checked:after:translate-x-[24px] sm:peer-checked:after:translate-x-[28px]
-                      peer-checked:after:border-white
-                    `}
-                  />
-                </div>
-              </div>
-            </label>
-
-            <label
-              htmlFor="income-toggle-map"
-              className={`
-                flex items-center justify-between 
-                border-t border-gem/20 mt-2 pt-2
-                bg-white/95 p-2 sm:p-3 rounded-md cursor-pointer
-                gap-1.5 sm:gap-0
-              `}
-            >
-              <div className="flex items-center gap-1.5 sm:gap-2 flex-1 min-w-0">
-                <div className="text-gem flex-shrink-0">
-                  <MdAttachMoney size={20} className="sm:w-6 sm:h-6" />
-                </div>
-                <div className="flex flex-col min-w-0">
-                  <label className="font-medium text-gem text-xs sm:text-sm">
-                    Income Intelligence
-                  </label>
-                  <p className="text-xs sm:text-sm text-gem/80 mt-1 ">Enable smart income data</p>
-                  <p className="text-[10px] text-gray-500 mt-0.5">
-                    Updated on:{' '}
-                    <span className="text-[#115740] font-medium">{getYesterdayDate()}</span>
-                  </p>
-                </div>
-              </div>
-
-              <div className="flex items-center gap-1 sm:gap-2 flex-shrink-0">
-                <button
-                  onClick={handleIncomeRefetch}
-                  className="text-gem-green hover:text-gem-green/80 p-1"
-                  title="Refresh income data"
-                  disabled={isIncomeRefetching}
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="18"
-                    height="18"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    className={isIncomeRefetching ? 'animate-spin' : ''}
-                  >
-                    <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2" />
-                  </svg>
-                </button>
-                <div
-                  className="flex bg-gray-100 rounded p-0.5 border border-gray-200 flex-shrink-0"
-                  onClick={e => e.preventDefault()}
-                >
-                  <button
-                    onClick={e => {
-                      e.stopPropagation();
-                      setIncomeSample(true);
-                    }}
-                    className={`
-                      px-2 py-0.5 sm:px-3 sm:py-1 text-[10px] sm:text-xs rounded transition-all duration-200
-                      ${
-                        incomeSample
-                          ? 'bg-white shadow-sm text-gem-green font-medium'
-                          : 'text-gray-500 hover:text-gray-700'
-                      }
-                    `}
-                  >
-                    Sample
-                  </button>
-                  <button
-                    onClick={e => {
-                      e.stopPropagation();
-                      setIncomeSample(false);
-                    }}
-                    className={`
-                      px-2 py-0.5 sm:px-3 sm:py-1 text-[10px] sm:text-xs rounded transition-all duration-200
-                      ${
-                        !incomeSample
-                          ? 'bg-white shadow-sm text-gem-green font-medium'
-                          : 'text-gray-500 hover:text-gray-700'
-                      }
-                    `}
-                  >
-                    Full
-                  </button>
-                </div>
-                <div className="relative flex-shrink-0 ml-1 sm:ml-0">
-                  <input
-                    id="income-toggle-map"
-                    type="checkbox"
-                    checked={includeIncome}
-                    onChange={() => {
-                      switchIncomeLayer();
-                    }}
-                    className="sr-only peer"
-                  />
-                  <div
-                    className={`
-                      cursor-pointer
-                      w-12 h-6 sm:w-14 sm:h-7 bg-gray-200
-                      peer-focus:outline-none peer-focus:ring-4
-                      peer-focus:ring-gem-green/20
-                      rounded-full peer
-                      peer-checked:bg-gem-green
-                      after:content-['']
-                      after:absolute
-                      after:top-[2px]
-                      after:left-[2px]
-                      after:bg-white
-                      after:border-gray-300
-                      after:border
-                      after:rounded-full
-                      after:h-5
-                      after:w-5
-                      after:transition-all
-                      peer-checked:after:translate-x-[24px] sm:peer-checked:after:translate-x-[28px]
-                      peer-checked:after:border-white
-                    `}
-                  />
-                </div>
-              </div>
-            </label>
-
-            <label
-              htmlFor="real-estate-toggle-map"
-              className={`
-                flex items-center justify-between 
-                border-t border-gem/20 mt-2 pt-2
-                bg-white/95 p-2 sm:p-3 rounded-md cursor-pointer
-                gap-1.5 sm:gap-0
-              `}
-            >
-              <div className="flex items-center gap-1.5 sm:gap-2 flex-1 min-w-0">
-                <div className="text-gem flex-shrink-0">
-                  <MdHome size={20} className="sm:w-6 sm:h-6" />
-                </div>
-                <div className="flex flex-col min-w-0">
-                  <label className="font-medium text-gem text-xs sm:text-sm">
-                    Real Estate Intelligence
-                  </label>
-                  <p className="text-xs sm:text-sm text-gem/80 mt-1">Enable smart real estate data</p>
-                  <p className="text-[10px] text-gray-500 mt-0.5">
-                    Updated on:{' '}
-                    <span className="text-[#115740] font-medium">{getYesterdayDate()}</span>
-                  </p>
-                </div>
-              </div>
-
-              <div className="flex items-center gap-1 sm:gap-2 flex-shrink-0">
-                <button
-                  onClick={handleRealEstateRefetch}
-                  className="text-gem-green hover:text-gem-green/80 p-1"
-                  title="Refresh real estate data"
-                  disabled={isRealEstateRefetching}
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="18"
-                    height="18"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    className={isRealEstateRefetching ? 'animate-spin' : ''}
-                  >
-                    <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2" />
-                  </svg>
-                </button>
-                <div
-                  className="flex bg-gray-100 rounded p-0.5 border border-gray-200 flex-shrink-0"
-                  onClick={e => e.preventDefault()}
-                >
-                  <button
-                    onClick={e => {
-                      e.stopPropagation();
-                      setRealEstateSample(true);
-                    }}
-                    className={`
-                      px-2 py-0.5 sm:px-3 sm:py-1 text-[10px] sm:text-xs rounded transition-all duration-200
-                      ${
-                        realEstateSample
-                          ? 'bg-white shadow-sm text-gem-green font-medium'
-                          : 'text-gray-500 hover:text-gray-700'
-                      }
-                    `}
-                  >
-                    Sample
-                  </button>
-                  <button
-                    onClick={e => {
-                      e.stopPropagation();
-                      setRealEstateSample(false);
-                    }}
-                    className={`
-                      px-2 py-0.5 sm:px-3 sm:py-1 text-[10px] sm:text-xs rounded transition-all duration-200
-                      ${
-                        !realEstateSample
-                          ? 'bg-white shadow-sm text-gem-green font-medium'
-                          : 'text-gray-500 hover:text-gray-700'
-                      }
-                    `}
-                  >
-                    Full
-                  </button>
-                </div>
-                <div className="relative flex-shrink-0 ml-1 sm:ml-0">
-                  <input
-                    id="real-estate-toggle-map"
-                    type="checkbox"
-                    checked={includeRealEstate}
-                    onChange={() => {
-                      switchRealEstateLayer();
-                    }}
-                    className="sr-only peer"
-                  />
-                  <div
-                    className={`
-                      cursor-pointer
-                      w-12 h-6 sm:w-14 sm:h-7 bg-gray-200
-                      peer-focus:outline-none peer-focus:ring-4
-                      peer-focus:ring-gem-green/20
-                      rounded-full peer
-                      peer-checked:bg-gem-green
-                      after:content-['']
-                      after:absolute
-                      after:top-[2px]
-                      after:left-[2px]
-                      after:bg-white
-                      after:border-gray-300
-                      after:border
-                      after:rounded-full
-                      after:h-5
-                      after:w-5
-                      after:transition-all
-                      peer-checked:after:translate-x-[24px] sm:peer-checked:after:translate-x-[28px]
-                      peer-checked:after:border-white
-                    `}
-                  />
-                </div>
-              </div>
-            </label>
+            />
+            <span className="hidden sm:inline">Area Intelligence</span>
           </div>
-        </div>
+        </button>
+
+        {isOpen && (
+          <div className="absolute left-0 mt-2 w-[min(calc(100vw-1rem),20rem)] sm:min-w-[26rem] sm:max-w-[42rem] z-50">
+            <div
+              className={`
+                relative flex flex-col p-3 sm:p-4 rounded-lg border
+                transition-all duration-200 ease-in-out
+                text-gray-100 bg-gem-gradient border-gem-green/20
+                aria-disabled:opacity-80 aria-disabled:cursor-not-allowed
+              `}
+              title={'Activate area intelligence'}
+            >
+              <div className="font-semibold text-white text-sm sm:text-base">Area Intelligence</div>
+              <p className="text-[11px] sm:text-xs text-gray-300 mt-1">
+                Only one intelligence layer can be active at a time
+              </p>
+
+              {/* Loading overlay */}
+              {isCheckingCost && (
+                <div className="absolute inset-0 bg-black/30 rounded-lg flex items-center justify-center z-10">
+                  <div className="bg-white rounded-lg px-4 py-2 text-sm text-gray-700 font-medium shadow-lg">
+                    Checking availability...
+                  </div>
+                </div>
+              )}
+
+              {/* Population Intelligence */}
+              <label
+                htmlFor="population-toggle-map"
+                className={`
+                  flex items-center justify-between
+                  border-t border-gem/20 mt-2 pt-2
+                  bg-white/95 p-2 sm:p-3 rounded-md cursor-pointer
+                  gap-1.5 sm:gap-1
+                `}
+              >
+                <div className="flex items-center gap-1.5 sm:gap-2 flex-1 min-w-0">
+                  <div className="text-gem flex-shrink-0">
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="18"
+                      height="18"
+                      className="sm:w-5 sm:h-5 min-w-[18px] sm:min-w-5"
+                    >
+                      <g>
+                        <path
+                          d="M18 7.16C17.94 7.15 17.87 7.15 17.81 7.16C16.43 7.11 15.33 5.98 15.33 4.58C15.33 3.15 16.48 2 17.91 2C19.34 2 20.49 3.16 20.49 4.58C20.48 5.98 19.38 7.11 18 7.16Z"
+                          strokeWidth="1.5"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          stroke="currentColor"
+                        />
+                        <path
+                          d="M16.9699 14.44C18.3399 14.67 19.8499 14.43 20.9099 13.72C22.3199 12.78 22.3199 11.24 20.9099 10.3C19.8399 9.59004 18.3099 9.35003 16.9399 9.59003"
+                          strokeWidth="1.5"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          stroke="currentColor"
+                        />
+                        <path
+                          d="M5.96998 7.16C6.02998 7.15 6.09998 7.15 6.15998 7.16C7.53998 7.11 8.63998 5.98 8.63998 4.58C8.63998 3.15 7.48998 2 6.05998 2C4.62998 2 3.47998 3.16 3.47998 4.58C3.48998 5.98 4.58998 7.11 5.96998 7.16Z"
+                          strokeWidth="1.5"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          stroke="currentColor"
+                        />
+                        <path
+                          d="M6.99994 14.44C5.62994 14.67 4.11994 14.43 3.05994 13.72C1.64994 12.78 1.64994 11.24 3.05994 10.3C4.12994 9.59004 5.65994 9.35003 7.02994 9.59003"
+                          strokeWidth="1.5"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          stroke="currentColor"
+                        />
+                        <path
+                          d="M12 14.63C11.94 14.62 11.87 14.62 11.81 14.63C10.43 14.58 9.32996 13.45 9.32996 12.05C9.32996 10.62 10.48 9.46997 11.91 9.46997C13.34 9.46997 14.49 10.63 14.49 12.05C14.48 13.45 13.38 14.59 12 14.63Z"
+                          strokeWidth="1.5"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          stroke="currentColor"
+                        />
+                        <path
+                          d="M9.08997 17.78C7.67997 18.72 7.67997 20.26 9.08997 21.2C10.69 22.27 13.31 22.27 14.91 21.2C16.32 20.26 16.32 18.72 14.91 17.78C13.32 16.72 10.69 16.72 9.08997 17.78Z"
+                          strokeWidth="1.5"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          stroke="currentColor"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                  <div className="flex flex-col min-w-0">
+                    <label className="font-medium text-gem text-xs sm:text-sm">
+                      Population Intelligence
+                    </label>
+                    <p className="text-xs sm:text-sm text-gem/80 mt-1 ">
+                      Enable smart population data
+                    </p>
+                    <p className="text-[10px] text-gray-500 mt-0.5">
+                      Updated on:{' '}
+                      <span className="text-[#115740] font-medium">{getYesterdayDate()}</span>
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-1 sm:gap-2 flex-shrink-0">
+                  <button
+                    onClick={handlePopulationRefetch}
+                    className="text-gem-green hover:text-gem-green/80 p-1"
+                    title="Refresh population data"
+                    disabled={isPopulationRefetching}
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="18"
+                      height="18"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className={isPopulationRefetching ? 'animate-spin' : ''}
+                    >
+                      <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2" />
+                    </svg>
+                  </button>
+                  <div
+                    className="flex bg-gray-100 rounded p-0.5 border border-gray-200 flex-shrink-0"
+                    onClick={e => e.preventDefault()}
+                  >
+                    <button
+                      onClick={e => {
+                        e.stopPropagation();
+                        setPopulationSample(true);
+                      }}
+                      className={`
+                        px-2 py-0.5 sm:px-3 sm:py-1 text-[10px] sm:text-xs rounded transition-all duration-200
+                        ${
+                          populationSample
+                            ? 'bg-white shadow-sm text-gem-green font-medium'
+                            : 'text-gray-500 hover:text-gray-700'
+                        }
+                      `}
+                    >
+                      Sample
+                    </button>
+                    <button
+                      onClick={handlePopulationFull}
+                      className={`
+                        px-2 py-0.5 sm:px-3 sm:py-1 text-[10px] sm:text-xs rounded transition-all duration-200
+                        ${
+                          !populationSample
+                            ? 'bg-white shadow-sm text-gem-green font-medium'
+                            : 'text-gray-500 hover:text-gray-700'
+                        }
+                      `}
+                    >
+                      Full
+                    </button>
+                  </div>
+                  <div className="relative flex-shrink-0 ml-1 sm:ml-0">
+                    <input
+                      id="population-toggle-map"
+                      type="checkbox"
+                      checked={includePopulation}
+                      onChange={handlePopulationToggle}
+                      disabled={isCheckingCost}
+                      className="sr-only peer"
+                    />
+                    <div
+                      className={`
+                        cursor-pointer
+                        w-12 h-6 sm:w-14 sm:h-7 bg-gray-200
+                        peer-focus:outline-none peer-focus:ring-4
+                        peer-focus:ring-gem-green/20
+                        rounded-full peer
+                        peer-checked:bg-gem-green
+                        peer-disabled:opacity-50
+                        after:content-['']
+                        after:absolute
+                        after:top-[2px]
+                        after:left-[2px]
+                        after:bg-white
+                        after:border-gray-300
+                        after:border
+                        after:rounded-full
+                        after:h-5
+                        after:w-5
+                        after:transition-all
+                        peer-checked:after:translate-x-[24px] sm:peer-checked:after:translate-x-[28px]
+                        peer-checked:after:border-white
+                      `}
+                    />
+                  </div>
+                </div>
+              </label>
+
+              {/* Income Intelligence */}
+              <label
+                htmlFor="income-toggle-map"
+                className={`
+                  flex items-center justify-between
+                  border-t border-gem/20 mt-2 pt-2
+                  bg-white/95 p-2 sm:p-3 rounded-md cursor-pointer
+                  gap-1.5 sm:gap-0
+                `}
+              >
+                <div className="flex items-center gap-1.5 sm:gap-2 flex-1 min-w-0">
+                  <div className="text-gem flex-shrink-0">
+                    <MdAttachMoney size={20} className="sm:w-6 sm:h-6" />
+                  </div>
+                  <div className="flex flex-col min-w-0">
+                    <label className="font-medium text-gem text-xs sm:text-sm">
+                      Income Intelligence
+                    </label>
+                    <p className="text-xs sm:text-sm text-gem/80 mt-1 ">Enable smart income data</p>
+                    <p className="text-[10px] text-gray-500 mt-0.5">
+                      Updated on:{' '}
+                      <span className="text-[#115740] font-medium">{getYesterdayDate()}</span>
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-1 sm:gap-2 flex-shrink-0">
+                  <button
+                    onClick={handleIncomeRefetch}
+                    className="text-gem-green hover:text-gem-green/80 p-1"
+                    title="Refresh income data"
+                    disabled={isIncomeRefetching}
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="18"
+                      height="18"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className={isIncomeRefetching ? 'animate-spin' : ''}
+                    >
+                      <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2" />
+                    </svg>
+                  </button>
+                  <div
+                    className="flex bg-gray-100 rounded p-0.5 border border-gray-200 flex-shrink-0"
+                    onClick={e => e.preventDefault()}
+                  >
+                    <button
+                      onClick={e => {
+                        e.stopPropagation();
+                        setIncomeSample(true);
+                      }}
+                      className={`
+                        px-2 py-0.5 sm:px-3 sm:py-1 text-[10px] sm:text-xs rounded transition-all duration-200
+                        ${
+                          incomeSample
+                            ? 'bg-white shadow-sm text-gem-green font-medium'
+                            : 'text-gray-500 hover:text-gray-700'
+                        }
+                      `}
+                    >
+                      Sample
+                    </button>
+                    <button
+                      onClick={handleIncomeFull}
+                      className={`
+                        px-2 py-0.5 sm:px-3 sm:py-1 text-[10px] sm:text-xs rounded transition-all duration-200
+                        ${
+                          !incomeSample
+                            ? 'bg-white shadow-sm text-gem-green font-medium'
+                            : 'text-gray-500 hover:text-gray-700'
+                        }
+                      `}
+                    >
+                      Full
+                    </button>
+                  </div>
+                  <div className="relative flex-shrink-0 ml-1 sm:ml-0">
+                    <input
+                      id="income-toggle-map"
+                      type="checkbox"
+                      checked={includeIncome}
+                      onChange={handleIncomeToggle}
+                      disabled={isCheckingCost}
+                      className="sr-only peer"
+                    />
+                    <div
+                      className={`
+                        cursor-pointer
+                        w-12 h-6 sm:w-14 sm:h-7 bg-gray-200
+                        peer-focus:outline-none peer-focus:ring-4
+                        peer-focus:ring-gem-green/20
+                        rounded-full peer
+                        peer-checked:bg-gem-green
+                        peer-disabled:opacity-50
+                        after:content-['']
+                        after:absolute
+                        after:top-[2px]
+                        after:left-[2px]
+                        after:bg-white
+                        after:border-gray-300
+                        after:border
+                        after:rounded-full
+                        after:h-5
+                        after:w-5
+                        after:transition-all
+                        peer-checked:after:translate-x-[24px] sm:peer-checked:after:translate-x-[28px]
+                        peer-checked:after:border-white
+                      `}
+                    />
+                  </div>
+                </div>
+              </label>
+
+              {/* Real Estate Intelligence */}
+              <label
+                htmlFor="real-estate-toggle-map"
+                className={`
+                  flex items-center justify-between
+                  border-t border-gem/20 mt-2 pt-2
+                  bg-white/95 p-2 sm:p-3 rounded-md cursor-pointer
+                  gap-1.5 sm:gap-0
+                `}
+              >
+                <div className="flex items-center gap-1.5 sm:gap-2 flex-1 min-w-0">
+                  <div className="text-gem flex-shrink-0">
+                    <MdHome size={20} className="sm:w-6 sm:h-6" />
+                  </div>
+                  <div className="flex flex-col min-w-0">
+                    <label className="font-medium text-gem text-xs sm:text-sm">
+                      Real Estate Intelligence
+                    </label>
+                    <p className="text-xs sm:text-sm text-gem/80 mt-1">Enable smart real estate data</p>
+                    <p className="text-[10px] text-gray-500 mt-0.5">
+                      Updated on:{' '}
+                      <span className="text-[#115740] font-medium">{getYesterdayDate()}</span>
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-1 sm:gap-2 flex-shrink-0">
+                  <button
+                    onClick={handleRealEstateRefetch}
+                    className="text-gem-green hover:text-gem-green/80 p-1"
+                    title="Refresh real estate data"
+                    disabled={isRealEstateRefetching}
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="18"
+                      height="18"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className={isRealEstateRefetching ? 'animate-spin' : ''}
+                    >
+                      <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2" />
+                    </svg>
+                  </button>
+                  <div
+                    className="flex bg-gray-100 rounded p-0.5 border border-gray-200 flex-shrink-0"
+                    onClick={e => e.preventDefault()}
+                  >
+                    <button
+                      onClick={e => {
+                        e.stopPropagation();
+                        setRealEstateSample(true);
+                      }}
+                      className={`
+                        px-2 py-0.5 sm:px-3 sm:py-1 text-[10px] sm:text-xs rounded transition-all duration-200
+                        ${
+                          realEstateSample
+                            ? 'bg-white shadow-sm text-gem-green font-medium'
+                            : 'text-gray-500 hover:text-gray-700'
+                        }
+                      `}
+                    >
+                      Sample
+                    </button>
+                    <button
+                      onClick={handleRealEstateFull}
+                      className={`
+                        px-2 py-0.5 sm:px-3 sm:py-1 text-[10px] sm:text-xs rounded transition-all duration-200
+                        ${
+                          !realEstateSample
+                            ? 'bg-white shadow-sm text-gem-green font-medium'
+                            : 'text-gray-500 hover:text-gray-700'
+                        }
+                      `}
+                    >
+                      Full
+                    </button>
+                  </div>
+                  <div className="relative flex-shrink-0 ml-1 sm:ml-0">
+                    <input
+                      id="real-estate-toggle-map"
+                      type="checkbox"
+                      checked={includeRealEstate}
+                      onChange={handleRealEstateToggle}
+                      disabled={isCheckingCost}
+                      className="sr-only peer"
+                    />
+                    <div
+                      className={`
+                        cursor-pointer
+                        w-12 h-6 sm:w-14 sm:h-7 bg-gray-200
+                        peer-focus:outline-none peer-focus:ring-4
+                        peer-focus:ring-gem-green/20
+                        rounded-full peer
+                        peer-checked:bg-gem-green
+                        peer-disabled:opacity-50
+                        after:content-['']
+                        after:absolute
+                        after:top-[2px]
+                        after:left-[2px]
+                        after:bg-white
+                        after:border-gray-300
+                        after:border
+                        after:rounded-full
+                        after:h-5
+                        after:w-5
+                        after:transition-all
+                        peer-checked:after:translate-x-[24px] sm:peer-checked:after:translate-x-[28px]
+                        peer-checked:after:border-white
+                      `}
+                    />
+                  </div>
+                </div>
+              </label>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Paywall Modal */}
+      {paywallData && (
+        <IntelligencePaywallModal
+          onClose={handlePaywallClose}
+          onPurchaseSuccess={handlePaywallSuccess}
+          cartCostData={paywallData}
+          intelligenceNames={paywallIntelligences}
+        />
       )}
-    </div>
+    </>
   );
 };

--- a/src/components/Map/IntelligencePaywallModal.tsx
+++ b/src/components/Map/IntelligencePaywallModal.tsx
@@ -1,0 +1,594 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { MdClose, MdCheckCircleOutline, MdErrorOutline, MdArrowBack } from 'react-icons/md';
+import { LiaMapMarkedAltSolid } from 'react-icons/lia';
+import { useNavigate } from 'react-router-dom';
+import { useAuth, isGuestUser } from '../../context/AuthContext';
+import apiRequest from '../../services/apiRequest';
+import urls from '../../urls.json';
+import { Elements } from '@stripe/react-stripe-js';
+import { loadStripe } from '@stripe/stripe-js';
+import { toast } from 'sonner';
+import InlinePaymentMethod from '../CustomReportForm/components/InlinePaymentMethod';
+import PhoneVerificationStep from '../CustomReportForm/components/PhoneVerificationStep';
+
+const stripeKey = import.meta.env.VITE_STRIPE_PUBLIC_KEY;
+const stripePromise = stripeKey ? loadStripe(stripeKey) : null;
+
+export interface IntelligencePurchaseItem {
+  city_name: string;
+  country_name: string;
+  user_id: string;
+  cost: number;
+  expiration: string | null;
+  explanation: string;
+  is_currently_owned: boolean;
+  free_as_part_of_package: boolean | null;
+  description: string;
+  data_variables: Record<string, string>;
+  intelligence_name: string;
+}
+
+interface CartCostData {
+  total_cost: number;
+  intelligence_purchase_items: IntelligencePurchaseItem[];
+  dataset_purchase_items: unknown[];
+  report_purchase_items: unknown[];
+}
+
+interface IntelligencePaywallModalProps {
+  onClose: () => void;
+  onPurchaseSuccess: () => void;
+  cartCostData: CartCostData;
+  intelligenceNames: string[]; // e.g. ['Population', 'Income', 'Real Estate']
+}
+
+const formatPrice = (value: number) =>
+  `$${value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+type InlineView = 'main' | 'add-payment' | 'add-funds' | 'verify-phone';
+
+export const IntelligencePaywallModal: React.FC<IntelligencePaywallModalProps> = ({
+  onClose,
+  onPurchaseSuccess,
+  cartCostData,
+  intelligenceNames,
+}) => {
+  const navigate = useNavigate();
+  const { authResponse } = useAuth();
+  const isGuest = !!authResponse && isGuestUser(authResponse);
+  const [isPurchasing, setIsPurchasing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [purchaseSuccess, setPurchaseSuccess] = useState(false);
+  const [inlineView, setInlineView] = useState<InlineView>('main');
+  const [userPhone, setUserPhone] = useState<string | null>(null);
+  const [profileLoading, setProfileLoading] = useState(true);
+  // When in add-payment view and phone is missing AND no existing payment method, show phone verification first
+  const [paymentNeedsPhone, setPaymentNeedsPhone] = useState(false);
+  const [hasPaymentMethod, setHasPaymentMethod] = useState(false);
+
+  // Fetch user profile (phone) and payment methods on mount
+  useEffect(() => {
+    const fetchUserData = async () => {
+      if (!authResponse?.localId) {
+        setProfileLoading(false);
+        return;
+      }
+      try {
+        // Fetch profile and payment methods in parallel
+        const [profileRes, paymentRes] = await Promise.allSettled([
+          apiRequest({
+            url: urls.user_profile,
+            method: 'POST',
+            isAuthRequest: true,
+            body: { user_id: authResponse.localId },
+          }),
+          apiRequest({
+            url: `${urls.list_stripe_payment_methods}?user_id=${authResponse.localId}`,
+            method: 'GET',
+            isAuthRequest: true,
+          }),
+        ]);
+
+        if (profileRes.status === 'fulfilled') {
+          const profile = profileRes.value?.data?.data || profileRes.value?.data;
+          const phone = profile?.phone || null;
+          setUserPhone(phone && phone.trim() ? phone : null);
+        }
+
+        if (paymentRes.status === 'fulfilled') {
+          const methods = paymentRes.value?.data?.data || paymentRes.value?.data;
+          setHasPaymentMethod(Array.isArray(methods) && methods.length > 0);
+        }
+      } catch {
+        // Non-critical
+      } finally {
+        setProfileLoading(false);
+      }
+    };
+    fetchUserData();
+  }, [authResponse?.localId]);
+
+  // When entering add-payment, check if phone verification is needed
+  // Skip if user already has a payment method on file
+  useEffect(() => {
+    if (inlineView === 'add-payment' && !profileLoading) {
+      setPaymentNeedsPhone(!userPhone && !hasPaymentMethod);
+    }
+  }, [inlineView, profileLoading, userPhone, hasPaymentMethod]);
+
+  const purchasableItems = cartCostData.intelligence_purchase_items.filter(
+    item => !item.is_currently_owned
+  );
+
+  const handlePurchase = useCallback(async () => {
+    if (isGuest) {
+      onClose();
+      navigate('/auth?mode=register');
+      return;
+    }
+
+    if (!authResponse?.localId) {
+      onClose();
+      navigate('/auth');
+      return;
+    }
+
+    setIsPurchasing(true);
+    setError(null);
+
+    try {
+      const requestBody = {
+        user_id: authResponse.localId,
+        country_name: '',
+        city_name: '',
+        datasets: [] as string[],
+        intelligences: intelligenceNames,
+        displayed_price: cartCostData.total_cost,
+        report: '',
+        report_potential_business_type: '',
+      };
+
+      await apiRequest({
+        url: urls.purchase_items,
+        method: 'POST',
+        body: requestBody,
+        isAuthRequest: true,
+      });
+
+      setPurchaseSuccess(true);
+      setTimeout(() => {
+        onPurchaseSuccess();
+        onClose();
+      }, 1500);
+    } catch (err: unknown) {
+      let errorMessage = 'An error occurred while processing your purchase.';
+
+      if (err && typeof err === 'object' && 'response' in err) {
+        const apiError = err as {
+          response?: { data?: { message?: string; detail?: string; error?: string } | string };
+        };
+        const errorData = apiError.response?.data;
+
+        if (errorData && typeof errorData === 'object') {
+          if (errorData.message) {
+            errorMessage = errorData.message;
+          } else if (errorData.detail) {
+            errorMessage = errorData.detail;
+          } else if (errorData.error) {
+            errorMessage = errorData.error;
+          }
+        } else if (typeof errorData === 'string') {
+          errorMessage = errorData;
+        }
+      } else if (err instanceof Error) {
+        errorMessage = err.message.replace(/\s*\(Status:\s*\d+\)/g, '');
+      }
+
+      // Route to inline flows based on error type
+      const lowerError = errorMessage.toLowerCase();
+      if (lowerError.includes('payment method') || lowerError.includes('paymentintent')) {
+        if (!stripePromise) {
+          toast.error('Payment system is unavailable. Please try again later or contact support.');
+          setError('Payment system is currently unavailable.');
+          return;
+        }
+        setError('No payment method on file. Please add a card to continue.');
+        setInlineView('add-payment');
+      } else if (lowerError.includes('insufficient balance') || lowerError.includes('wallet')) {
+        setError('Insufficient funds. Please top up your wallet to continue.');
+        setInlineView('add-funds');
+      } else if (lowerError.includes('phone') || lowerError.includes('verify')) {
+        setError('Phone verification required. Please verify your phone number first.');
+        setInlineView('verify-phone');
+      } else {
+        setError(errorMessage);
+      }
+    } finally {
+      setIsPurchasing(false);
+    }
+  }, [isGuest, authResponse, intelligenceNames, cartCostData.total_cost, onPurchaseSuccess, onClose, navigate]);
+
+  // After inline flow completes, retry purchase
+  const handlePaymentMethodAdded = useCallback(() => {
+    setInlineView('main');
+    setError(null);
+    // Auto-retry purchase after adding payment method
+    handlePurchase();
+  }, [handlePurchase]);
+
+  const handlePhoneVerified = useCallback((phone: string) => {
+    setUserPhone(phone);
+    setInlineView('main');
+    setError(null);
+    // Auto-retry purchase after phone verification
+    setTimeout(() => handlePurchase(), 500);
+  }, [handlePurchase]);
+
+  const handleFundsAdded = useCallback(() => {
+    setInlineView('main');
+    setError(null);
+    // Auto-retry purchase after adding funds
+    handlePurchase();
+  }, [handlePurchase]);
+
+  const modalContent = (() => {
+    // Success state
+    if (purchaseSuccess) {
+      return (
+        <div className="fixed inset-0 z-[9999] flex items-center justify-center p-4 bg-black/50">
+          <div className="bg-white rounded-xl shadow-2xl max-w-md w-full p-8 text-center">
+            <MdCheckCircleOutline className="text-green-500 text-6xl mx-auto mb-4" />
+            <h2 className="text-2xl font-semibold text-gray-900 mb-2">Purchase Successful!</h2>
+            <p className="text-gray-600">Activating your intelligence layer...</p>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="fixed inset-0 z-[9999] flex items-center justify-center p-4 bg-black/50">
+        <div className="bg-white rounded-xl shadow-2xl max-w-lg w-full max-h-[90vh] overflow-hidden flex flex-col">
+          {/* Header — gem gradient */}
+          <div className="bg-gem-gradient px-6 py-5">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                {inlineView !== 'main' && (
+                  <button
+                    onClick={() => { setInlineView('main'); setError(null); }}
+                    className="text-white/70 hover:text-white transition-colors mr-1"
+                    aria-label="Back"
+                  >
+                    <MdArrowBack size={22} />
+                  </button>
+                )}
+                <div className="bg-white/20 rounded-lg p-2">
+                  <LiaMapMarkedAltSolid size={24} className="text-white" />
+                </div>
+                <div>
+                  <h2 className="text-xl font-semibold text-white">
+                    {inlineView === 'main'
+                      ? 'You Discovered A Premium Feature'
+                      : inlineView === 'add-payment'
+                        ? (paymentNeedsPhone ? 'Verify Phone Number' : 'Add Payment Method')
+                        : inlineView === 'add-funds'
+                          ? 'Add Funds'
+                          : 'Verify Phone Number'}
+                  </h2>
+                  <p className="text-sm text-white/80">Area Intelligence</p>
+                </div>
+              </div>
+              <button
+                onClick={onClose}
+                className="text-white/70 hover:text-white transition-colors"
+                aria-label="Close"
+              >
+                <MdClose size={24} />
+              </button>
+            </div>
+          </div>
+
+          {/* Content */}
+          <div className="flex-1 overflow-y-auto px-6 py-5">
+            {/* Inline: Add Payment Method (with phone verification gate) */}
+            {inlineView === 'add-payment' && (
+              paymentNeedsPhone ? (
+                <PhoneVerificationStep
+                  onVerificationSuccess={(phone) => {
+                    setUserPhone(phone);
+                    setPaymentNeedsPhone(false);
+                  }}
+                  compact
+                  title="Verify Your Phone"
+                  subtitle="A verified phone number is required before adding a payment method."
+                />
+              ) : (
+                <Elements stripe={stripePromise!}>
+                  <InlinePaymentMethod
+                    onPaymentMethodAdded={handlePaymentMethodAdded}
+                    onCancel={() => { setInlineView('main'); setError(null); }}
+                    userPhone={userPhone}
+                  />
+                </Elements>
+              )
+            )}
+
+            {/* Inline: Add Funds */}
+            {inlineView === 'add-funds' && (
+              <InlineAddFunds
+                onFundsAdded={handleFundsAdded}
+                onCancel={() => { setInlineView('main'); setError(null); }}
+              />
+            )}
+
+            {/* Inline: Phone Verification */}
+            {inlineView === 'verify-phone' && (
+              <PhoneVerificationStep
+                onVerificationSuccess={handlePhoneVerified}
+                compact
+                title="Verify Your Phone"
+                subtitle="Phone verification is required to complete your purchase."
+              />
+            )}
+
+            {/* Main purchase view */}
+            {inlineView === 'main' && (
+              <>
+                {isGuest && (
+                  <div className="bg-amber-50 border border-amber-200 rounded-lg px-4 py-3 mb-4">
+                    <p className="text-sm text-amber-800">
+                      You're a guest user. Please sign up to complete your purchase.
+                    </p>
+                  </div>
+                )}
+
+                {error && (
+                  <div className="bg-red-50 border border-red-200 rounded-lg px-4 py-3 mb-4">
+                    <div className="flex items-start gap-2">
+                      <MdErrorOutline className="text-red-500 text-xl flex-shrink-0 mt-0.5" />
+                      <p className="text-sm text-red-800">{error}</p>
+                    </div>
+                  </div>
+                )}
+
+                <div className="space-y-3">
+                  {purchasableItems.map(item => (
+                    <div
+                      key={item.intelligence_name}
+                      className="border border-gray-100 rounded-lg p-4 bg-gray-50"
+                    >
+                      <div className="flex items-start justify-between">
+                        <div className="flex-1">
+                          <h3 className="text-base font-semibold text-gray-900">
+                            {item.intelligence_name} Intelligence
+                          </h3>
+                          <p className="text-sm text-gray-600 mt-1">{item.description}</p>
+                          <p className="text-xs text-gray-500 mt-1 italic">{item.explanation}</p>
+                          {item.expiration && (
+                            <p className="text-xs text-gray-500 mt-1">
+                              Valid until: {new Date(item.expiration).toLocaleDateString()}
+                            </p>
+                          )}
+                        </div>
+                        <div className="text-right ml-4">
+                          {item.free_as_part_of_package ? (
+                            <span className="text-lg font-bold text-green-600">Free</span>
+                          ) : (
+                            <span className="text-lg font-bold text-[#115740]">
+                              {formatPrice(item.cost)}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+
+                      {/* Data variables preview */}
+                      {item.data_variables && Object.keys(item.data_variables).length > 0 && (
+                        <details className="mt-3">
+                          <summary className="text-xs text-[#115740] cursor-pointer font-medium">
+                            View included data variables ({Object.keys(item.data_variables).length})
+                          </summary>
+                          <div className="mt-2 grid grid-cols-1 gap-1 max-h-32 overflow-y-auto">
+                            {Object.entries(item.data_variables).map(([key, desc]) => (
+                              <div key={key} className="text-xs text-gray-600">
+                                <span className="font-medium text-gray-700">{key}</span>: {desc}
+                              </div>
+                            ))}
+                          </div>
+                        </details>
+                      )}
+                    </div>
+                  ))}
+                </div>
+
+                {!isGuest && (
+                  <div className="mt-4 bg-gray-50 border border-gray-100 rounded-lg px-4 py-3">
+                    <p className="text-xs text-gray-500">
+                      Questions? Reach us at{' '}
+                      <a href="tel:+966558188632" className="text-[#115740] font-medium hover:underline">
+                        +966 (55) 818 - 8632
+                      </a>
+                    </p>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+
+          {/* Footer — only show on main view */}
+          {inlineView === 'main' && (
+            <div className="border-t border-gray-200 px-6 py-4 bg-gray-50">
+              <div className="flex items-center justify-between mb-4">
+                <span className="text-sm text-gray-600">Total</span>
+                <span className="text-xl font-bold text-gray-900">
+                  {formatPrice(cartCostData.total_cost)}
+                </span>
+              </div>
+              <div className="flex gap-3">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="flex-1 bg-white border-2 border-gray-300 text-gray-700 py-3 rounded-lg font-semibold hover:bg-gray-50 transition-all"
+                >
+                  Not Now
+                </button>
+                <button
+                  type="button"
+                  onClick={handlePurchase}
+                  disabled={isPurchasing || purchasableItems.length === 0}
+                  className="flex-1 bg-[#115740] text-white py-3 rounded-lg font-semibold hover:bg-[#0d4632] transition-all disabled:bg-gray-400 disabled:cursor-not-allowed"
+                >
+                  {isPurchasing ? 'Processing...' : isGuest ? 'Sign Up to Purchase' : 'Purchase Now'}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  })();
+
+  // Portal to document.body to escape any parent stacking contexts (BottomDrawer transform, sidebar z-index)
+  return createPortal(modalContent, document.body);
+};
+
+/**
+ * Inline wallet top-up component for the paywall modal.
+ * Mirrors the AddFunds page but stays inside the modal.
+ */
+const InlineAddFunds: React.FC<{
+  onFundsAdded: () => void;
+  onCancel: () => void;
+}> = ({ onFundsAdded, onCancel }) => {
+  const { authResponse } = useAuth();
+  const [cost, setCost] = useState('');
+  const [inputError, setInputError] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleCostChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (value === '' || /^\d*\.?\d{0,2}$/.test(value)) {
+      setCost(value);
+      setInputError(null);
+    } else {
+      setInputError('Enter a valid amount (e.g. 10.99)');
+    }
+  };
+
+  const formatCost = (value: string) => {
+    const num = parseFloat(value);
+    if (!isNaN(num) && num >= 0) return num.toFixed(2);
+    return value;
+  };
+
+  const handleCostBlur = () => {
+    if (cost && !isNaN(parseFloat(cost))) setCost(formatCost(cost));
+  };
+
+  const handleCostFocus = () => {
+    const num = parseFloat(cost);
+    if (!isNaN(num)) setCost(String(num));
+    setInputError(null);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (inputError) return;
+
+    setErrorMessage(null);
+    setSubmitting(true);
+
+    try {
+      const amount = parseFloat(cost);
+      if (isNaN(amount) || amount <= 0) {
+        setErrorMessage('Please enter a valid amount.');
+        setSubmitting(false);
+        return;
+      }
+
+      if (!authResponse?.localId) {
+        setErrorMessage('User not authenticated.');
+        setSubmitting(false);
+        return;
+      }
+
+      await apiRequest({
+        url: urls.top_up_wallet,
+        method: 'POST',
+        body: {
+          amount: amount * 100, // convert dollars to cents
+          user_id: authResponse.localId,
+        },
+        isAuthRequest: true,
+      });
+
+      onFundsAdded();
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : 'An unexpected error occurred. Please try again later.'
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm">
+      <div className="mb-4">
+        <h3 className="text-lg font-semibold text-gray-900 mb-1">Top Up Your Wallet</h3>
+        <p className="text-sm text-gray-600">
+          Add funds to your wallet to complete this purchase.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="topup-amount" className="block text-sm font-medium text-gray-700 mb-1">
+            Amount (USD)
+          </label>
+          <input
+            id="topup-amount"
+            type="number"
+            inputMode="decimal"
+            step="0.01"
+            min="0"
+            value={cost}
+            onChange={handleCostChange}
+            onFocus={handleCostFocus}
+            onBlur={handleCostBlur}
+            className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary"
+            placeholder="0.00"
+            required
+          />
+          {inputError && <p className="text-red-500 text-sm mt-1">{inputError}</p>}
+        </div>
+
+        {errorMessage && (
+          <div className="p-3 bg-red-50 border border-red-200 rounded-lg">
+            <p className="text-red-600 text-sm">{errorMessage}</p>
+          </div>
+        )}
+
+        <div className="flex gap-3 pt-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={submitting}
+            className="flex-1 px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting || !cost}
+            className="flex-1 px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition duration-200"
+          >
+            {submitting ? 'Processing...' : 'Add Funds'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default IntelligencePaywallModal;


### PR DESCRIPTION
## Summary
- Calls `/calculate_cart_cost` before enabling any intel layer or switching to Full mode
- If `cost = 0` (already purchased) → proceeds normally, no interruption
- If `cost > 0` → shows paywall modal with item breakdown, pricing, and expiration
- Handles edge cases inline (user never leaves the modal):
  - Missing payment method → inline Stripe card form
  - Insufficient funds → inline wallet top-up
  - Missing phone → inline phone verification (with OTP paste support) before card form
  - Guest user → redirect to signup